### PR TITLE
Editar paragrafo com tag com delimitadores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.idea
 .project
 .classpath
+/src/.idea

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>br.com.digix</groupId>
     <artifactId>editordedocumento</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <name>Editor De Documento</name>
     <description>Framework desenvolvido para gerar relatorios no formato docx com mais facilidade</description>
     <url>https://github.com/somosdigix/editordedocumentos</url>
@@ -47,6 +47,12 @@
             <email>thg.vieira12@gmail.com</email>
             <organization>com.github.com/thgvieira</organization>
             <organizationUrl>https://github.com/thgvieira</organizationUrl>
+        </developer>
+        <developer>
+            <name>Caio Suzuki</name>
+            <email>cpolidoro@gmail.com</email>
+            <organization>com.github.com/caiosuzuki</organization>
+            <organizationUrl>https://github.com/caiosuzuki</organizationUrl>
         </developer>
     </developers>
 

--- a/src/main/java/editor/docx/paragrafo/EditorDeParagrafo.java
+++ b/src/main/java/editor/docx/paragrafo/EditorDeParagrafo.java
@@ -45,8 +45,9 @@ public class EditorDeParagrafo {
     }
 
     private void editarTagDoDocumento(XWPFRun linhaDoDocumento) {
-        String chaveParaSubstituicao = linhaDoDocumento.getText(INICIO_DA_TAG_NO_TEXTO);
-        if (Objects.nonNull(chaveParaSubstituicao) && mapaDeAtributos.containsKey(chaveParaSubstituicao)) {
+        String tagNoDocumento = linhaDoDocumento.getText(INICIO_DA_TAG_NO_TEXTO);
+        String chaveParaSubstituicao = tagNoDocumento.replace("${", "").replace("}", "");
+        if (Objects.nonNull(tagNoDocumento) && mapaDeAtributos.containsKey(chaveParaSubstituicao)) {
             String valorParaSubstituir = obterValorParaSubstituicao(chaveParaSubstituicao);
             linhaDoDocumento.setText(VAZIO, INICIO_DA_TAG_NO_TEXTO);
             String[] linhas = valorParaSubstituir.split(PULA_LINHA);

--- a/src/test/java/editor/docx/paragrafo/EditorDeParagrafoTest.java
+++ b/src/test/java/editor/docx/paragrafo/EditorDeParagrafoTest.java
@@ -1,53 +1,67 @@
 package editor.docx.paragrafo;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.junit.Assert;
 import org.junit.Test;
 
-import editor.docx.paragrafo.EditorDeParagrafo;
+import java.util.HashMap;
+import java.util.Map;
 
 public class EditorDeParagrafoTest {
 
-	@Test
-	public void deveEditarUmParagrafoDoTexto() throws Exception {
-		String conteudoDoTestoEsperado = "João do Pé de Feijão";
-		String atributoQueSeraAlteradoNoDocumento = "nomeDoFuncionario";
-		Map<String, Object> mapaDeAtributos = montarMapaDeAtributos(atributoQueSeraAlteradoNoDocumento,
-				conteudoDoTestoEsperado);
-		XWPFDocument documento = new XWPFDocument();
-		XWPFParagraph paragrafoDoDocumento = criarParagrafoNoDocumento(documento, atributoQueSeraAlteradoNoDocumento);
+    @Test
+    public void deveEditarUmParagrafoDoTexto() throws Exception {
+        String conteudoDoTextoEsperado = "João do Pé de Feijão";
+        String atributoQueSeraAlteradoNoDocumento = "nomeDoFuncionario";
+        Map<String, Object> mapaDeAtributos = montarMapaDeAtributos(atributoQueSeraAlteradoNoDocumento,
+                conteudoDoTextoEsperado);
+        XWPFDocument documento = new XWPFDocument();
+        XWPFParagraph paragrafoDoDocumento = criarParagrafoNoDocumento(documento, atributoQueSeraAlteradoNoDocumento);
 
-		EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
-		String textoAdicionadoNoDocumento = buscarPalavraNoArquivo(documento, conteudoDoTestoEsperado);
+        EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
+        String textoAdicionadoNoDocumento = buscarPalavraNoArquivo(documento, conteudoDoTextoEsperado);
 
-		Assert.assertEquals(conteudoDoTestoEsperado, textoAdicionadoNoDocumento);
-	}
+        Assert.assertEquals(conteudoDoTextoEsperado, textoAdicionadoNoDocumento);
+    }
 
-	private XWPFParagraph criarParagrafoNoDocumento(XWPFDocument documento, String atributoQueSeraAlteradoNoDocumento) {
-		XWPFParagraph paragrafoDoDocumento = documento.createParagraph();
-		XWPFRun linhaDoDocumento = paragrafoDoDocumento.createRun();
-		linhaDoDocumento.setText(atributoQueSeraAlteradoNoDocumento);
-		return paragrafoDoDocumento;
-	}
+    @Test
+    public void deveEditarUmParagrafoNoTextoUsandoTagComDelimitadores() throws Exception {
+        String conteudoDoTextoEsperado = "Marquinhos DJ";
+        String atributoQueSeraSubstituido = "nomeDoDJDaFesta";
+        String tagQueSeraAlteradaNoDocumento = "${" + atributoQueSeraSubstituido + "}";
+        Map<String, Object> mapaDeAtributos = montarMapaDeAtributos(atributoQueSeraSubstituido,
+                conteudoDoTextoEsperado);
+        XWPFDocument documento = new XWPFDocument();
+        XWPFParagraph paragrafoDoDocumento = criarParagrafoNoDocumento(documento, tagQueSeraAlteradaNoDocumento);
 
-	private Map<String, Object> montarMapaDeAtributos(String tagNoDocumento, String conteudoDoTestoEsperado) {
-		Map<String, Object> mapaDeAtributos = new HashMap<>();
-		mapaDeAtributos.put(tagNoDocumento, conteudoDoTestoEsperado);
-		return mapaDeAtributos;
-	}
+        EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
+        String textoAdicionadoNoDocumento = buscarPalavraNoArquivo(documento, conteudoDoTextoEsperado);
 
-	private String buscarPalavraNoArquivo(XWPFDocument documento, String conteudoParaBuscar) throws Exception {
-		return documento.getParagraphs().stream()
-				.filter(paragrafo -> verificarConteudoDoParagrafo(paragrafo, conteudoParaBuscar)).findFirst().get()
-				.getText();
-	}
+        Assert.assertEquals(conteudoDoTextoEsperado, textoAdicionadoNoDocumento);
+    }
 
-	private boolean verificarConteudoDoParagrafo(XWPFParagraph paragrafo, String conteudoParaBuscar) {
-		return paragrafo.getText().equals(conteudoParaBuscar);
-	}
+    private Map<String, Object> montarMapaDeAtributos(String tagNoDocumento, String conteudoDoTestoEsperado) {
+        Map<String, Object> mapaDeAtributos = new HashMap<>();
+        mapaDeAtributos.put(tagNoDocumento, conteudoDoTestoEsperado);
+        return mapaDeAtributos;
+    }
+
+    private XWPFParagraph criarParagrafoNoDocumento(XWPFDocument documento, String atributoQueSeraAlteradoNoDocumento) {
+        XWPFParagraph paragrafoDoDocumento = documento.createParagraph();
+        XWPFRun linhaDoDocumento = paragrafoDoDocumento.createRun();
+        linhaDoDocumento.setText(atributoQueSeraAlteradoNoDocumento);
+        return paragrafoDoDocumento;
+    }
+
+    private String buscarPalavraNoArquivo(XWPFDocument documento, String conteudoParaBuscar) throws Exception {
+        return documento.getParagraphs().stream()
+                .filter(paragrafo -> verificarConteudoDoParagrafo(paragrafo, conteudoParaBuscar)).findFirst().get()
+                .getText();
+    }
+
+    private boolean verificarConteudoDoParagrafo(XWPFParagraph paragrafo, String conteudoParaBuscar) {
+        return paragrafo.getText().equals(conteudoParaBuscar);
+    }
 }


### PR DESCRIPTION
Agora também é possível que o template do usuário tenha tags do tipo ${tagNoDocumentoParaSerSubstituida} em vez de somente tags em camelCase como tagNoDocumentoParaSerSubstituida. Isso facilita a legibilidade de templates para eventuais conferências do usuário do editordedocumentos. Apesar disso, caso o usuário opte por continuar utilizando apenas tags em camelCase, esta forma continua funcionando.