### PR TITLE
Corrigindo substituicao de tags dentro do mesmo trecho de paragrafo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
         <!-- Versão das dependencias -->
         <junit>4.13.1</junit>
-        <org.apache.poi>4.1.2</org.apache.poi>
+        <org.apache.poi>3.14</org.apache.poi>
         <com.itextpdf>5.5.9</com.itextpdf>
         <org.apache.poi.xwpf.converter.pdf>1.0.4</org.apache.poi.xwpf.converter.pdf>
         <fr.opensagres.xdocreport>1.0.5</fr.opensagres.xdocreport>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>br.com.digix</groupId>
     <artifactId>editordedocumento</artifactId>
-    <version>2.2.5</version>
+    <version>2.2.6</version>
     <name>Editor De Documento</name>
     <description>Framework desenvolvido para gerar relatorios no formato docx com mais facilidade</description>
     <url>https://github.com/somosdigix/editordedocumentos</url>

--- a/src/main/java/editor/docx/paragrafo/EditorDeParagrafo.java
+++ b/src/main/java/editor/docx/paragrafo/EditorDeParagrafo.java
@@ -66,8 +66,8 @@ public class EditorDeParagrafo {
                 .apply(textoDaRun);
     }
 
-    private boolean verificarSeChaveEstaContidaNoTexto(String chaveParaSubstituicao, String textoDaRun) {
-        return textoDaRun.contains(chaveParaSubstituicao);
+    private boolean verificarSeChaveEstaContidaNoTexto(String chaveParaSubstituicao, String conteudoDoTrechoDeParagrafo) {
+        return Objects.nonNull(conteudoDoTrechoDeParagrafo) && conteudoDoTrechoDeParagrafo.contains(chaveParaSubstituicao);
     }
 
     private String obterValorParaSubstituicao(String atributoDoDocumento) {

--- a/src/main/java/editor/docx/paragrafo/EditorDeParagrafo.java
+++ b/src/main/java/editor/docx/paragrafo/EditorDeParagrafo.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class EditorDeParagrafo {
 
@@ -40,18 +42,32 @@ public class EditorDeParagrafo {
 
     private void editarUmParagrafo(XWPFParagraph paragrafoDocumento) {
         if (Objects.nonNull(paragrafoDocumento.getRuns())) {
-            paragrafoDocumento.getRuns().forEach(linhaDoParagrado -> editarTagDoDocumento(linhaDoParagrado));
+            paragrafoDocumento.getRuns().forEach(this::editarTagDoDocumento);
         }
     }
 
-    private void editarTagDoDocumento(XWPFRun linhaDoDocumento) {
-        String chaveParaSubstituicao = linhaDoDocumento.getText(INICIO_DA_TAG_NO_TEXTO);
-        if (Objects.nonNull(chaveParaSubstituicao) && mapaDeAtributos.containsKey(chaveParaSubstituicao)) {
-            String valorParaSubstituir = obterValorParaSubstituicao(chaveParaSubstituicao);
-            linhaDoDocumento.setText(VAZIO, INICIO_DA_TAG_NO_TEXTO);
-            String[] linhas = valorParaSubstituir.split(PULA_LINHA);
-            Arrays.stream(linhas).forEach(linha -> formatarLinha(linhaDoDocumento, valorParaSubstituir, linha));
+    private void editarTagDoDocumento(XWPFRun trechoDeParagrafo) {
+        String conteudoDoTrechoDeParagrafo = trechoDeParagrafo.getText(INICIO_DA_TAG_NO_TEXTO);
+        List<String> chavesParaSubstituir = mapaDeAtributos.keySet().stream()
+                .filter(chaveParaSubstituicao -> verificarSeChaveEstaContidaNoTexto(chaveParaSubstituicao, conteudoDoTrechoDeParagrafo)).collect(Collectors.toList());
+        if (Objects.nonNull(conteudoDoTrechoDeParagrafo) && !chavesParaSubstituir.isEmpty()) {
+            String conteudoDoTrechoDeParagrafoComTagsSubstituidas = obterTrechoDeParagrafoComTagsSubstituidas(conteudoDoTrechoDeParagrafo);
+            trechoDeParagrafo.setText(VAZIO, INICIO_DA_TAG_NO_TEXTO);
+            String[] linhas = conteudoDoTrechoDeParagrafoComTagsSubstituidas.split(PULA_LINHA);
+            Arrays.stream(linhas).forEach(linha -> formatarLinha(trechoDeParagrafo, conteudoDoTrechoDeParagrafoComTagsSubstituidas, linha));
         }
+    }
+
+    private String obterTrechoDeParagrafoComTagsSubstituidas(String textoDaRun) {
+        return mapaDeAtributos.entrySet().stream().map(chaveEValor ->
+                        (Function<String, String>) textoParaSubstituicao ->
+                                textoParaSubstituicao.replace(chaveEValor.getKey(), obterValorParaSubstituicao(chaveEValor.getKey())))
+                .reduce(Function.identity(), Function::andThen)
+                .apply(textoDaRun);
+    }
+
+    private boolean verificarSeChaveEstaContidaNoTexto(String chaveParaSubstituicao, String textoDaRun) {
+        return textoDaRun.contains(chaveParaSubstituicao);
     }
 
     private String obterValorParaSubstituicao(String atributoDoDocumento) {

--- a/src/test/java/editor/docx/paragrafo/EditorDeParagrafoTest.java
+++ b/src/test/java/editor/docx/paragrafo/EditorDeParagrafoTest.java
@@ -21,7 +21,7 @@ public class EditorDeParagrafoTest {
         XWPFParagraph paragrafoDoDocumento = criarParagrafoNoDocumentoComApenasUmTrecho(documento, atributoQueSeraAlteradoNoDocumento);
 
         EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
-        String textoAdicionadoNoDocumento = buscarPalavraNoArquivo(documento, conteudoDoTextoEsperado);
+        String textoAdicionadoNoDocumento = buscarTextoNoArquivo(documento, conteudoDoTextoEsperado);
 
         Assert.assertEquals(conteudoDoTextoEsperado, textoAdicionadoNoDocumento);
     }
@@ -38,7 +38,7 @@ public class EditorDeParagrafoTest {
 
         EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
 
-        String textoAdicionadoNoDocumento = buscarPalavraNoArquivo(documento, conteudoDoTextoEsperado);
+        String textoAdicionadoNoDocumento = buscarTextoNoArquivo(documento, conteudoDoTextoEsperado);
         Assert.assertEquals(conteudoDoTextoEsperado, textoAdicionadoNoDocumento);
     }
 
@@ -54,7 +54,22 @@ public class EditorDeParagrafoTest {
 
         EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
 
-        String textoAdicionadoNoDocumento = buscarPalavraNoArquivo(documento, conteudoDoTextoEsperado);
+        String textoAdicionadoNoDocumento = buscarTextoNoArquivo(documento, conteudoDoTextoEsperado);
+        Assert.assertEquals(conteudoDoTextoEsperado, textoAdicionadoNoDocumento);
+    }
+
+    @Test
+    public void deveEditarUmParagrafoQuandoOTrechoDoParagrafoForVazio() throws Exception {
+        String conteudoDoTextoEsperado = "";
+        XWPFDocument documento = new XWPFDocument();
+        XWPFParagraph paragrafoDoDocumento = documento.createParagraph();
+        paragrafoDoDocumento.createRun();
+        Map<String, Object> mapaDeAtributos = new HashMap<>();
+        mapaDeAtributos.put("nomeDaCidade", "Campo Grande");
+
+        EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
+
+        String textoAdicionadoNoDocumento = buscarTextoNoArquivo(documento, conteudoDoTextoEsperado);
         Assert.assertEquals(conteudoDoTextoEsperado, textoAdicionadoNoDocumento);
     }
 
@@ -71,7 +86,7 @@ public class EditorDeParagrafoTest {
         return paragrafoDoDocumento;
     }
 
-    private String buscarPalavraNoArquivo(XWPFDocument documento, String conteudoParaBuscar) throws Exception {
+    private String buscarTextoNoArquivo(XWPFDocument documento, String conteudoParaBuscar) throws Exception {
         return documento.getParagraphs().stream()
                 .filter(paragrafo -> verificarConteudoDoParagrafo(paragrafo, conteudoParaBuscar)).findFirst().get()
                 .getText();

--- a/src/test/java/editor/docx/paragrafo/EditorDeParagrafoTest.java
+++ b/src/test/java/editor/docx/paragrafo/EditorDeParagrafoTest.java
@@ -4,7 +4,6 @@ import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -19,11 +18,43 @@ public class EditorDeParagrafoTest {
         Map<String, Object> mapaDeAtributos = montarMapaDeAtributos(atributoQueSeraAlteradoNoDocumento,
                 conteudoDoTextoEsperado);
         XWPFDocument documento = new XWPFDocument();
-        XWPFParagraph paragrafoDoDocumento = criarParagrafoNoDocumento(documento, atributoQueSeraAlteradoNoDocumento);
+        XWPFParagraph paragrafoDoDocumento = criarParagrafoNoDocumentoComApenasUmTrecho(documento, atributoQueSeraAlteradoNoDocumento);
 
         EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
         String textoAdicionadoNoDocumento = buscarPalavraNoArquivo(documento, conteudoDoTextoEsperado);
 
+        Assert.assertEquals(conteudoDoTextoEsperado, textoAdicionadoNoDocumento);
+    }
+
+    @Test
+    public void deveEditarUmParagrafoQuandoOTrechoDoParagrafoTiverMaisDeUmaPalavra() throws Exception {
+        String conteudoDoTextoQueDeveSerSubstituido = "Carlos Silva";
+        String conteudoDoTextoEsperado = "e assina também Carlos Silva doravante citado como Contratado";
+        String textoOriginalDoDocumentoComAsTags = "e assina também nomeDoFuncionario doravante citado como Contratado";
+        Map<String, Object> mapaDeAtributos = new HashMap<>();
+        mapaDeAtributos.put("nomeDoFuncionario", conteudoDoTextoQueDeveSerSubstituido);
+        XWPFDocument documento = new XWPFDocument();
+        XWPFParagraph paragrafoDoDocumento = criarParagrafoNoDocumentoComApenasUmTrecho(documento, textoOriginalDoDocumentoComAsTags);
+
+        EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
+
+        String textoAdicionadoNoDocumento = buscarPalavraNoArquivo(documento, conteudoDoTextoEsperado);
+        Assert.assertEquals(conteudoDoTextoEsperado, textoAdicionadoNoDocumento);
+    }
+
+    @Test
+    public void deveEditarUmParagrafoQuandoOTrechoDoParagrafoTiverChavesParaSubstituirSemEspaçoEntreElas() throws Exception {
+        String conteudoDoTextoEsperado = "na cidade de Campo Grande/MS";
+        String textoOriginalDoDocumentoComAsTags = "na cidade de nomeDaCidade/siglaDoUF";
+        Map<String, Object> mapaDeAtributos = new HashMap<>();
+        mapaDeAtributos.put("nomeDaCidade", "Campo Grande");
+        mapaDeAtributos.put("siglaDoUF", "MS");
+        XWPFDocument documento = new XWPFDocument();
+        XWPFParagraph paragrafoDoDocumento = criarParagrafoNoDocumentoComApenasUmTrecho(documento, textoOriginalDoDocumentoComAsTags);
+
+        EditorDeParagrafo.comMapaDeAtributos(mapaDeAtributos).editarParagrafosDoDocumento(paragrafoDoDocumento);
+
+        String textoAdicionadoNoDocumento = buscarPalavraNoArquivo(documento, conteudoDoTextoEsperado);
         Assert.assertEquals(conteudoDoTextoEsperado, textoAdicionadoNoDocumento);
     }
 
@@ -33,10 +64,10 @@ public class EditorDeParagrafoTest {
         return mapaDeAtributos;
     }
 
-    private XWPFParagraph criarParagrafoNoDocumento(XWPFDocument documento, String atributoQueSeraAlteradoNoDocumento) {
+    private XWPFParagraph criarParagrafoNoDocumentoComApenasUmTrecho(XWPFDocument documento, String conteudoDoTrechoDoParagrafo) {
         XWPFParagraph paragrafoDoDocumento = documento.createParagraph();
         XWPFRun linhaDoDocumento = paragrafoDoDocumento.createRun();
-        linhaDoDocumento.setText(atributoQueSeraAlteradoNoDocumento);
+        linhaDoDocumento.setText(conteudoDoTrechoDoParagrafo);
         return paragrafoDoDocumento;
     }
 


### PR DESCRIPTION
Previamente, as tags eram substituídas iterando sobre XWPFRuns, que estavam sendo interpretadas como palavras únicas dentro de um parágrafo, porém esta abordagem era incorreta pois uma XWPFRun é um trecho do parágrafo com características como fonte, cor, e negrito iguais. Dessa forma, por vezes a XWPFRun continha uma tag, porém ela não era encontrada para ser substituída.