### PR TITLE
Trocando itextpdf por pdfbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,21 @@ versões:
   <version>2.2.4</version>
 </dependency>
  ```
- ultima versão: 
  - v2.2.6 (02/08/2021)
   ``` sh
 <dependency>
   <groupId>br.com.digix</groupId>
   <artifactId>editordedocumento</artifactId>
   <version>2.2.6</version>
+</dependency>
+ ```
+ ultima versão: 
+ - v2.2.7 (31/05/2023)
+  ``` sh
+<dependency>
+  <groupId>br.com.digix</groupId>
+  <artifactId>editordedocumento</artifactId>
+  <version>2.2.7</version>
 </dependency>
  ```
  
@@ -77,8 +85,11 @@ versões:
   EditorDeArquivoDeTexto.editarArquivoDocx().docxComTabelas(dadosDasTabelas, formatacao).editar(arquivoQueSeraEditado, mapaDeDadosDoDocumento);
   ```
  
- - V2.2.6
+ - V2.2.6  
   Correções de bugs menores na substituição de tags.
+
+ - V2.2.7  
+  Remoção da lib iTextPDF em favor da lib PDFBox.
 
 aqui você pode encontrar esse framework compilado para outras liguagens, como Scala, Kotlin, Groovy...
 https://search.maven.org/artifact/br.com.digix/editordedocumento

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <encoding>${project.build.sourceEnconding}</encoding>
+                    <encoding>${project.build.sourceEncoding}</encoding>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <!-- Versão das dependencias -->
         <junit>4.13.1</junit>
         <org.apache.poi>3.14</org.apache.poi>
-        <com.itextpdf>5.5.9</com.itextpdf>
         <org.apache.poi.xwpf.converter.pdf>1.0.4</org.apache.poi.xwpf.converter.pdf>
         <fr.opensagres.xdocreport>1.0.5</fr.opensagres.xdocreport>
     </properties>
@@ -218,11 +217,6 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>${org.apache.poi}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.itextpdf</groupId>
-            <artifactId>itextpdf</artifactId>
-            <version>${com.itextpdf}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>br.com.digix</groupId>
     <artifactId>editordedocumento</artifactId>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <name>Editor De Documento</name>
     <description>Framework desenvolvido para gerar relatorios no formato docx com mais facilidade</description>
     <url>https://github.com/somosdigix/editordedocumentos</url>
@@ -99,7 +99,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <encoding>${project.build.souvrceEnconding}</encoding>
+                    <encoding>${project.build.sourceEnconding}</encoding>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,11 @@
             <version>${com.itextpdf}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.28</version>
+        </dependency>
+        <dependency>
             <groupId>fr.opensagres.xdocreport</groupId>
             <artifactId>org.apache.poi.xwpf.converter.pdf</artifactId>
             <version>${org.apache.poi.xwpf.converter.pdf}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
             <organization>com.github.com/caiosuzuki</organization>
             <organizationUrl>https://github.com/caiosuzuki</organizationUrl>
         </developer>
+        <developer>
+            <name>Adriano Wahl</name>
+            <email>adriano.wah@gmail.com</email>
+            <organization>com.github.com/adrianokw</organization>
+            <organizationUrl>https://github.com/adrianokw</organizationUrl>
+        </developer>
     </developers>
 
     <scm>

--- a/src/main/java/utils/PdfUtils.java
+++ b/src/main/java/utils/PdfUtils.java
@@ -1,8 +1,5 @@
 package utils;
 
-import com.itextpdf.text.pdf.PdfCopy;
-import com.itextpdf.text.pdf.PdfImportedPage;
-import com.itextpdf.text.pdf.PdfReader;
 import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.poi.xwpf.converter.pdf.PdfConverter;
@@ -10,20 +7,16 @@ import org.apache.poi.xwpf.converter.pdf.PdfOptions;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 
 import java.io.*;
-import java.nio.file.Files;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class PdfUtils {
 
 	private static final String EXTENSAO_DO_ARQUIVO = ".pdf";
-	private static File arquivoConvertido;
 
 	public static File converterDocxParaPdf(File arquivoDocx, String nomeDoArquivoDeSaida, PdfOptions... opcoes)
 			throws ErroAoConverterDocxParaPdf {
 		try {
 			String nomeDoArquivo = nomeDoArquivoDeSaida.concat(EXTENSAO_DO_ARQUIVO);
-			arquivoConvertido = new File(nomeDoArquivo);
+			File arquivoConvertido = new File(nomeDoArquivo);
 			InputStream inputStream = new FileInputStream(arquivoDocx);
 			XWPFDocument docx = new XWPFDocument(inputStream);
 			PdfOptions options = null;
@@ -32,10 +25,10 @@ public class PdfUtils {
 			}
 			OutputStream pdfDeSaidaOutputStream = new FileOutputStream(arquivoConvertido);
 			PdfConverter.getInstance().convert(docx, pdfDeSaidaOutputStream, options);
+			return arquivoConvertido;
 		} catch (Exception exception) {
 			throw new ErroAoConverterDocxParaPdf();
 		}
-		return arquivoConvertido;
 	}
 
 	public static byte[] converterDocxParaPdf(byte[] dados) throws ErroAoConverterDocxParaPdf {
@@ -60,31 +53,5 @@ public class PdfUtils {
 		// TODO avaliar opção de uso de memória, talvez receber como parâmetro
 		pdfMergerUtility.mergeDocuments(MemoryUsageSetting.setupMainMemoryOnly());
 		return new File(nomeDoArquivoDeSaidaComExtensao);
-	}
-
-	private static List<byte[]> lerBytesDosArquivos(List<File> arquivos) throws IOException {
-		return arquivos.stream().filter(file -> file != null).map(file -> adicionarBytesDosArquivos(file)).collect(Collectors.toList());
-	}
-
-	private static byte[] adicionarBytesDosArquivos(File file) {
-		try {
-			return Files.readAllBytes(file.toPath());
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	private static void concatenarDocumento(PdfCopy copiadorDeDocumento, byte[] documento) {
-		try {
-			PdfReader leitorDePaginas = new PdfReader(documento);
-			for (int paginaAtualDoDocumento = 1; paginaAtualDoDocumento <= leitorDePaginas.getNumberOfPages(); paginaAtualDoDocumento++) {
-				PdfImportedPage primeiraPagina = copiadorDeDocumento.getImportedPage(leitorDePaginas, paginaAtualDoDocumento);
-				copiadorDeDocumento.addPage(primeiraPagina);
-			}
-			copiadorDeDocumento.freeReader(leitorDePaginas);
-			leitorDePaginas.close();
-		} catch (Exception excecao) {
-			throw new RuntimeException(excecao);
-		}
 	}
 }

--- a/src/main/java/utils/PdfUtils.java
+++ b/src/main/java/utils/PdfUtils.java
@@ -43,6 +43,8 @@ public class PdfUtils {
 		}
 	}
 
+	// TODO avaliar opção de uso de memória para os dois métodos de união de arquivo, talvez receber como parâmetro
+	//  pode ser mais performático em algumas situações usando arquivos temporários
 	public static File unirArquivosPdf(String nomeDoArquivoDeSaida, File... arquivosPdf) throws IOException {
 		PDFMergerUtility pdfMergerUtility = new PDFMergerUtility();
 		String nomeDoArquivoDeSaidaComExtensao = nomeDoArquivoDeSaida + EXTENSAO_DO_ARQUIVO;
@@ -50,8 +52,19 @@ public class PdfUtils {
 		for (File arquivo : arquivosPdf) {
 			pdfMergerUtility.addSource(arquivo);
 		}
-		// TODO avaliar opção de uso de memória, talvez receber como parâmetro
 		pdfMergerUtility.mergeDocuments(MemoryUsageSetting.setupMainMemoryOnly());
 		return new File(nomeDoArquivoDeSaidaComExtensao);
+	}
+
+	public static byte[] unirArquivosPdf(byte[]... arquivosPdf) throws IOException {
+		PDFMergerUtility pdfMergerUtility = new PDFMergerUtility();
+		ByteArrayOutputStream pdfDeSaidaOutputStream = new ByteArrayOutputStream();
+		pdfMergerUtility.setDestinationStream(pdfDeSaidaOutputStream);
+		for (byte[] arquivo : arquivosPdf) {
+			ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(arquivo);
+			pdfMergerUtility.addSource(byteArrayInputStream);
+		}
+		pdfMergerUtility.mergeDocuments(MemoryUsageSetting.setupMainMemoryOnly());
+		return pdfDeSaidaOutputStream.toByteArray();
 	}
 }

--- a/src/main/java/utils/PdfUtils.java
+++ b/src/main/java/utils/PdfUtils.java
@@ -7,6 +7,7 @@ import org.apache.poi.xwpf.converter.pdf.PdfOptions;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 
 import java.io.*;
+import java.util.Arrays;
 
 public class PdfUtils {
 
@@ -60,10 +61,8 @@ public class PdfUtils {
 		PDFMergerUtility pdfMergerUtility = new PDFMergerUtility();
 		ByteArrayOutputStream pdfDeSaidaOutputStream = new ByteArrayOutputStream();
 		pdfMergerUtility.setDestinationStream(pdfDeSaidaOutputStream);
-		for (byte[] arquivo : arquivosPdf) {
-			ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(arquivo);
-			pdfMergerUtility.addSource(byteArrayInputStream);
-		}
+		Arrays.stream(arquivosPdf).map(ByteArrayInputStream::new)
+				.forEachOrdered(pdfMergerUtility::addSource);
 		pdfMergerUtility.mergeDocuments(MemoryUsageSetting.setupMainMemoryOnly());
 		return pdfDeSaidaOutputStream.toByteArray();
 	}

--- a/src/test/java/utils/PdfUtilsTest.java
+++ b/src/test/java/utils/PdfUtilsTest.java
@@ -57,7 +57,6 @@ public class PdfUtilsTest {
         assertEquals(EXTENSAO_DO_ARQUIVO_ESPERADA, extensaoDoArquivoConvertido);
     }
 
-
     @Test
     public void deveUnirVariosArquivosPdfEmUmUnicoRelatorioComByteArrays() throws Exception {
         Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));

--- a/src/test/java/utils/PdfUtilsTest.java
+++ b/src/test/java/utils/PdfUtilsTest.java
@@ -41,11 +41,11 @@ public class PdfUtilsTest {
     }
 
     @Test
-    public void deveUnirVariosArquivosPdfEmUmUnicoRelatorio() throws Exception {
+    public void deveUnirVariosArquivosPdfEmUmUnicoRelatorioComFiles() throws Exception {
         Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
         File primeiroArquivoPDF = new File(pathDoRelatorio.toString());
         File segundoArquivoPDF = new File(pathDoRelatorio.toString());
-        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(primeiroArquivoPDF,segundoArquivoPDF);
+        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(primeiroArquivoPDF, segundoArquivoPDF);
 
         String nomeDoArquivoDeSaida = "arquivoDeSaida";
         arquivoDeSaida = PdfUtils.unirArquivosPdf(nomeDoArquivoDeSaida, primeiroArquivoPDF, segundoArquivoPDF);
@@ -57,19 +57,47 @@ public class PdfUtilsTest {
         assertEquals(EXTENSAO_DO_ARQUIVO_ESPERADA, extensaoDoArquivoConvertido);
     }
 
+
+    @Test
+    public void deveUnirVariosArquivosPdfEmUmUnicoRelatorioComByteArrays() throws Exception {
+        Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
+        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoRelatorio.toString()), new File(pathDoRelatorio.toString()));
+        byte[] primeiroArquivoPDF = Files.readAllBytes(pathDoRelatorio);
+        byte[] segundoArquivoPDF = Files.readAllBytes(pathDoRelatorio);
+
+
+        byte[] arquivoDeSaida = PdfUtils.unirArquivosPdf(primeiroArquivoPDF, segundoArquivoPDF);
+        Integer quantidadeDePaginasDoArquivoDeSaida = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(arquivoDeSaida);
+
+        assertNotNull(arquivoDeSaida);
+        assertEquals(quantidadeDePaginasEsperada, quantidadeDePaginasDoArquivoDeSaida);
+    }
+
     private Integer calcularQuantidadeDePaginasDeUmOuMaisDocumentos(File... documentos) throws IOException {
         int quantidadeDePaginasDoArquivoDeSaida = 0;
-        PDDocument leitorDePaginas;
         for (File documento : documentos) {
             byte[] bytesDoDocumento = Files.readAllBytes(documento.toPath());
-            leitorDePaginas = PDDocument.load(bytesDoDocumento);
-            quantidadeDePaginasDoArquivoDeSaida += leitorDePaginas.getNumberOfPages();
-            leitorDePaginas.close();
+            quantidadeDePaginasDoArquivoDeSaida += calcularQuantidadeDePaginasDeUmDocumento(bytesDoDocumento);
         }
         return quantidadeDePaginasDoArquivoDeSaida;
     }
 
-    private String obterExtensaoDoAquivo(File arquivoDeSaida){
+    private static int calcularQuantidadeDePaginasDeUmDocumento(byte[] bytesDoDocumento) throws IOException {
+        PDDocument leitorDePaginas = PDDocument.load(bytesDoDocumento);
+        int quantidadeDePaginasDoArquivoDeSaida = leitorDePaginas.getNumberOfPages();
+        leitorDePaginas.close();
+        return quantidadeDePaginasDoArquivoDeSaida;
+    }
+
+    private Integer calcularQuantidadeDePaginasDeUmOuMaisDocumentos(byte[]... documentos) throws IOException {
+        int quantidadeDePaginasDoArquivoDeSaida = 0;
+        for (byte[] bytesDoDocumento : documentos) {
+            quantidadeDePaginasDoArquivoDeSaida += calcularQuantidadeDePaginasDeUmDocumento(bytesDoDocumento);
+        }
+        return quantidadeDePaginasDoArquivoDeSaida;
+    }
+
+    private String obterExtensaoDoAquivo(File arquivoDeSaida) {
         return URLConnection.guessContentTypeFromName(arquivoDeSaida.getName());
     }
 

--- a/src/test/java/utils/PdfUtilsTest.java
+++ b/src/test/java/utils/PdfUtilsTest.java
@@ -1,21 +1,18 @@
 package utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.junit.After;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 
-import com.itextpdf.text.List;
-import com.itextpdf.text.pdf.PdfReader;
-import org.junit.After;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class PdfUtilsTest {
 
@@ -61,14 +58,14 @@ public class PdfUtilsTest {
     }
 
     private Integer calcularQuantidadeDePaginasDeUmOuMaisDocumentos(File... documentos) throws IOException {
-        Integer quantidadeDePaginasDoArquivoDeSaida = 0;
-        PdfReader leitorDePaginas = null;
-        for (File documento : Arrays.asList(documentos)) {
+        int quantidadeDePaginasDoArquivoDeSaida = 0;
+        PDDocument leitorDePaginas;
+        for (File documento : documentos) {
             byte[] bytesDoDocumento = Files.readAllBytes(documento.toPath());
-            leitorDePaginas = new PdfReader(bytesDoDocumento);
+            leitorDePaginas = PDDocument.load(bytesDoDocumento);
             quantidadeDePaginasDoArquivoDeSaida += leitorDePaginas.getNumberOfPages();
+            leitorDePaginas.close();
         }
-        leitorDePaginas.close();
         return quantidadeDePaginasDoArquivoDeSaida;
     }
 


### PR DESCRIPTION
Removendo o uso de itextpdf versão 5 por incompatibilidade de licenças. No lugar, foi utilizada a lib PDFbox, que tem licença compatível com a nossa. Era utilizada para união de PDFs. Agora há também a opção de unir PDFs por byte array e não só por File.