### PR TITLE
Criando sobrecargas do método unirArquivosPdf para receber e retornar ByteBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ versões:
 </dependency>
  ```
   última versão: 
- - v2.2.8 (04/07/2023)
+ - v2.3.0 (04/07/2023)
    ``` sh
 <dependency>
   <groupId>br.com.digix</groupId>
   <artifactId>editordedocumento</artifactId>
-  <version>2.2.8</version>
+  <version>2.3.0</version>
 </dependency>
  ```
  
@@ -99,7 +99,7 @@ versões:
  - V2.2.7  
   Remoção da lib iTextPDF em favor da lib PDFBox.
   
- - V2.2.8
+ - V2.3.0
   Inclusão de sobrecargas do método unirArquivosPdf da classe PdfUtils para lidar com ByteBuffer.
 
 aqui você pode encontrar esse framework compilado para outras liguagens, como Scala, Kotlin, Groovy...

--- a/README.md
+++ b/README.md
@@ -40,13 +40,21 @@ versões:
   <version>2.2.6</version>
 </dependency>
  ```
- ultima versão: 
  - v2.2.7 (31/05/2023)
   ``` sh
 <dependency>
   <groupId>br.com.digix</groupId>
   <artifactId>editordedocumento</artifactId>
   <version>2.2.7</version>
+</dependency>
+ ```
+  última versão: 
+ - v2.2.8 (04/07/2023)
+   ``` sh
+<dependency>
+  <groupId>br.com.digix</groupId>
+  <artifactId>editordedocumento</artifactId>
+  <version>2.2.8</version>
 </dependency>
  ```
  
@@ -90,6 +98,9 @@ versões:
 
  - V2.2.7  
   Remoção da lib iTextPDF em favor da lib PDFBox.
+  
+ - V2.2.8
+  Inclusão de sobrecargas do método unirArquivosPdf da classe PdfUtils para lidar com ByteBuffer.
 
 aqui você pode encontrar esse framework compilado para outras liguagens, como Scala, Kotlin, Groovy...
 https://search.maven.org/artifact/br.com.digix/editordedocumento

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>br.com.digix</groupId>
     <artifactId>editordedocumento</artifactId>
-    <version>2.2.7</version>
+    <version>2.2.8</version>
     <name>Editor De Documento</name>
     <description>Framework desenvolvido para gerar relatorios no formato docx com mais facilidade</description>
     <url>https://github.com/somosdigix/editordedocumentos</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>br.com.digix</groupId>
     <artifactId>editordedocumento</artifactId>
-    <version>2.2.8</version>
+    <version>2.3.0</version>
     <name>Editor De Documento</name>
     <description>Framework desenvolvido para gerar relatorios no formato docx com mais facilidade</description>
     <url>https://github.com/somosdigix/editordedocumentos</url>

--- a/src/main/java/utils/PdfUtils.java
+++ b/src/main/java/utils/PdfUtils.java
@@ -7,7 +7,10 @@ import org.apache.poi.xwpf.converter.pdf.PdfOptions;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 
 import java.io.*;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 
 public class PdfUtils {
 
@@ -58,12 +61,27 @@ public class PdfUtils {
 	}
 
 	public static byte[] unirArquivosPdf(byte[]... arquivosPdf) throws IOException {
+		Stream<byte[]> streamDosBytesDosArquivosPdf = Arrays.stream(arquivosPdf);
+		return unirArquivosPdf(streamDosBytesDosArquivosPdf);
+	}
+
+	private static byte[] unirArquivosPdf(Stream<byte[]> streamDosBytesDosArquivosPdf) throws IOException {
 		PDFMergerUtility pdfMergerUtility = new PDFMergerUtility();
+		streamDosBytesDosArquivosPdf.map(ByteArrayInputStream::new)
+				.forEachOrdered(pdfMergerUtility::addSource);
 		ByteArrayOutputStream pdfDeSaidaOutputStream = new ByteArrayOutputStream();
 		pdfMergerUtility.setDestinationStream(pdfDeSaidaOutputStream);
-		Arrays.stream(arquivosPdf).map(ByteArrayInputStream::new)
-				.forEachOrdered(pdfMergerUtility::addSource);
 		pdfMergerUtility.mergeDocuments(MemoryUsageSetting.setupMainMemoryOnly());
 		return pdfDeSaidaOutputStream.toByteArray();
+	}
+
+	public static ByteBuffer unirArquivosPdf(List<ByteBuffer> arquivosPdf) throws IOException {
+		Stream<byte[]> streamDosBytesDosArquivosPdf = arquivosPdf.stream().map(ByteBuffer::array);
+		byte[] bytesDoArquivoUnificado = unirArquivosPdf(streamDosBytesDosArquivosPdf);
+		return ByteBuffer.wrap(bytesDoArquivoUnificado);
+	}
+
+	public static ByteBuffer unirArquivosPdf(ByteBuffer... arquivosPdf) throws IOException {
+		return unirArquivosPdf(Arrays.asList(arquivosPdf));
 	}
 }

--- a/src/test/java/utils/PdfUtilsTest.java
+++ b/src/test/java/utils/PdfUtilsTest.java
@@ -67,7 +67,6 @@ public class PdfUtilsTest {
         byte[] primeiroArquivoPDF = Files.readAllBytes(pathDoArquivo);
         byte[] segundoArquivoPDF = Files.readAllBytes(pathDoArquivo);
 
-
         byte[] arquivoDeSaida = PdfUtils.unirArquivosPdf(primeiroArquivoPDF, segundoArquivoPDF);
         Integer quantidadeDePaginasDoArquivoDeSaida = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(arquivoDeSaida);
 
@@ -96,7 +95,6 @@ public class PdfUtilsTest {
         Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoArquivo.toString()), new File(pathDoArquivo.toString()));
         ByteBuffer primeiroArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoArquivo));
         ByteBuffer segundoArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoArquivo));
-
 
         ByteBuffer arquivoDeSaida = PdfUtils.unirArquivosPdf(primeiroArquivoPDF, segundoArquivoPDF);
         Integer quantidadeDePaginasDoArquivoDeSaida = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(arquivoDeSaida);

--- a/src/test/java/utils/PdfUtilsTest.java
+++ b/src/test/java/utils/PdfUtilsTest.java
@@ -25,8 +25,8 @@ public class PdfUtilsTest {
 
     @Test
     public void deveConverterUmArquivoComExtensaoDocxParaPdf() throws Exception {
-        Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.docx"));
-        File arquivoDocx = new File(pathDoRelatorio.toString());
+        Path pathDoArquivo = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.docx"));
+        File arquivoDocx = new File(pathDoArquivo.toString());
 
         String nomeDoArquivoDeSaida = "arquivoDeSaida";
         arquivoDeSaida = PdfUtils.converterDocxParaPdf(arquivoDocx, nomeDoArquivoDeSaida);
@@ -44,10 +44,10 @@ public class PdfUtilsTest {
     }
 
     @Test
-    public void deveUnirVariosArquivosPdfEmUmUnicoRelatorioComFiles() throws Exception {
-        Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
-        File primeiroArquivoPDF = new File(pathDoRelatorio.toString());
-        File segundoArquivoPDF = new File(pathDoRelatorio.toString());
+    public void deveUnirVariosArquivosPdfEmUmUnicoArquivoComFiles() throws Exception {
+        Path pathDoArquivo = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
+        File primeiroArquivoPDF = new File(pathDoArquivo.toString());
+        File segundoArquivoPDF = new File(pathDoArquivo.toString());
         Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(primeiroArquivoPDF, segundoArquivoPDF);
 
         String nomeDoArquivoDeSaida = "arquivoDeSaida";
@@ -61,11 +61,11 @@ public class PdfUtilsTest {
     }
 
     @Test
-    public void deveUnirVariosArquivosPdfEmUmUnicoRelatorioComByteArrays() throws Exception {
-        Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
-        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoRelatorio.toString()), new File(pathDoRelatorio.toString()));
-        byte[] primeiroArquivoPDF = Files.readAllBytes(pathDoRelatorio);
-        byte[] segundoArquivoPDF = Files.readAllBytes(pathDoRelatorio);
+    public void deveUnirVariosArquivosPdfEmUmUnicoArquivoComByteArrays() throws Exception {
+        Path pathDoArquivo = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
+        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoArquivo.toString()), new File(pathDoArquivo.toString()));
+        byte[] primeiroArquivoPDF = Files.readAllBytes(pathDoArquivo);
+        byte[] segundoArquivoPDF = Files.readAllBytes(pathDoArquivo);
 
 
         byte[] arquivoDeSaida = PdfUtils.unirArquivosPdf(primeiroArquivoPDF, segundoArquivoPDF);
@@ -76,11 +76,11 @@ public class PdfUtilsTest {
     }
 
     @Test
-    public void deveUnirVariosArquivosPdfEmUmUnicoRelatorioComListaDeByteBuffers() throws Exception {
-        Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
-        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoRelatorio.toString()), new File(pathDoRelatorio.toString()));
-        ByteBuffer primeiroArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoRelatorio));
-        ByteBuffer segundoArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoRelatorio));
+    public void deveUnirVariosArquivosPdfEmUmUnicoArquivoComListaDeByteBuffers() throws Exception {
+        Path pathDoArquivo = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
+        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoArquivo.toString()), new File(pathDoArquivo.toString()));
+        ByteBuffer primeiroArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoArquivo));
+        ByteBuffer segundoArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoArquivo));
         List<ByteBuffer> listaDeArquivosParaUnir = Arrays.asList(primeiroArquivoPDF, segundoArquivoPDF);
 
         ByteBuffer arquivoDeSaida = PdfUtils.unirArquivosPdf(listaDeArquivosParaUnir);
@@ -91,11 +91,11 @@ public class PdfUtilsTest {
     }
 
     @Test
-    public void deveUnirVariosArquivosPdfEmUmUnicoRelatorioComByteBuffers() throws Exception {
-        Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
-        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoRelatorio.toString()), new File(pathDoRelatorio.toString()));
-        ByteBuffer primeiroArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoRelatorio));
-        ByteBuffer segundoArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoRelatorio));
+    public void deveUnirVariosArquivosPdfEmUmUnicoArquivoComByteBuffers() throws Exception {
+        Path pathDoArquivo = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
+        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoArquivo.toString()), new File(pathDoArquivo.toString()));
+        ByteBuffer primeiroArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoArquivo));
+        ByteBuffer segundoArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoArquivo));
 
 
         ByteBuffer arquivoDeSaida = PdfUtils.unirArquivosPdf(primeiroArquivoPDF, segundoArquivoPDF);

--- a/src/test/java/utils/PdfUtilsTest.java
+++ b/src/test/java/utils/PdfUtilsTest.java
@@ -7,9 +7,12 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URLConnection;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -72,6 +75,36 @@ public class PdfUtilsTest {
         assertEquals(quantidadeDePaginasEsperada, quantidadeDePaginasDoArquivoDeSaida);
     }
 
+    @Test
+    public void deveUnirVariosArquivosPdfEmUmUnicoRelatorioComListaDeByteBuffers() throws Exception {
+        Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
+        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoRelatorio.toString()), new File(pathDoRelatorio.toString()));
+        ByteBuffer primeiroArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoRelatorio));
+        ByteBuffer segundoArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoRelatorio));
+        List<ByteBuffer> listaDeArquivosParaUnir = Arrays.asList(primeiroArquivoPDF, segundoArquivoPDF);
+
+        ByteBuffer arquivoDeSaida = PdfUtils.unirArquivosPdf(listaDeArquivosParaUnir);
+        Integer quantidadeDePaginasDoArquivoDeSaida = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(arquivoDeSaida);
+
+        assertNotNull(arquivoDeSaida);
+        assertEquals(quantidadeDePaginasEsperada, quantidadeDePaginasDoArquivoDeSaida);
+    }
+
+    @Test
+    public void deveUnirVariosArquivosPdfEmUmUnicoRelatorioComByteBuffers() throws Exception {
+        Path pathDoRelatorio = Paths.get(PATH_RESOURCES_DOCUMENTOS_DE_TESTE.concat("documentoDeTeste.pdf"));
+        Integer quantidadeDePaginasEsperada = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(new File(pathDoRelatorio.toString()), new File(pathDoRelatorio.toString()));
+        ByteBuffer primeiroArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoRelatorio));
+        ByteBuffer segundoArquivoPDF = ByteBuffer.wrap(Files.readAllBytes(pathDoRelatorio));
+
+
+        ByteBuffer arquivoDeSaida = PdfUtils.unirArquivosPdf(primeiroArquivoPDF, segundoArquivoPDF);
+        Integer quantidadeDePaginasDoArquivoDeSaida = calcularQuantidadeDePaginasDeUmOuMaisDocumentos(arquivoDeSaida);
+
+        assertNotNull(arquivoDeSaida);
+        assertEquals(quantidadeDePaginasEsperada, quantidadeDePaginasDoArquivoDeSaida);
+    }
+
     private Integer calcularQuantidadeDePaginasDeUmOuMaisDocumentos(File... documentos) throws IOException {
         int quantidadeDePaginasDoArquivoDeSaida = 0;
         for (File documento : documentos) {
@@ -92,6 +125,14 @@ public class PdfUtilsTest {
         int quantidadeDePaginasDoArquivoDeSaida = 0;
         for (byte[] bytesDoDocumento : documentos) {
             quantidadeDePaginasDoArquivoDeSaida += calcularQuantidadeDePaginasDeUmDocumento(bytesDoDocumento);
+        }
+        return quantidadeDePaginasDoArquivoDeSaida;
+    }
+
+    private Integer calcularQuantidadeDePaginasDeUmOuMaisDocumentos(ByteBuffer... documentos) throws IOException {
+        int quantidadeDePaginasDoArquivoDeSaida = 0;
+        for (ByteBuffer documento : documentos) {
+            quantidadeDePaginasDoArquivoDeSaida += calcularQuantidadeDePaginasDeUmDocumento(documento.array());
         }
         return quantidadeDePaginasDoArquivoDeSaida;
     }


### PR DESCRIPTION
Criadas duas sobrecargas do método unirArquivosPdf do PdfUtils que até então recebia File ou byte[], para que seja possível passar como parâmetro ByteBuffers, retornando também ByteBuffers.
Criado método privado para reaproveitar trecho duplicado entre essas sobrecargas, que recebe um stream dos bytes do arquivos.